### PR TITLE
Allow multiple ProductSupply tags, contributor statements to be an array, allow further lookups for ProductFormFeature

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ribal/onix",
+    "name": "commonknowledge/onix",
     "description": "An ONIX 3.0 Parser",
     "type": "library",
     "license": "MIT",
@@ -7,6 +7,10 @@
         {
             "name": "Chris Ribal",
             "email": "c.ribal@ribal-webentwicklung.de"
+        },
+        {
+            "name": "Common Knowledge",
+            "email": "hello@commonknowledge.coop"
         }
     ],
     "require": {

--- a/src/Product/Contributor.php
+++ b/src/Product/Contributor.php
@@ -29,7 +29,7 @@ class Contributor
      *
      * @var array|NameIdentifier
      */
-    protected $NameIdentifiers = [];
+    protected $NameIdentifier = [];
 
     /**
      * NamesBeforeKey
@@ -80,9 +80,21 @@ class Contributor
      * @param NameIdentifier $NameIdentifier
      * @return void
      */
-    public function setNameIdentifier(NameIdentifier $NameIdentifier)
+    public function addNameIdentifier(NameIdentifier $NameIdentifier)
     {
-        $this->NameIdentifiers[] = $NameIdentifier;
+        echo "Hitting addNameIdentifier\n";
+        $this->NameIdentifier[] = $NameIdentifier;
+    }
+
+    /**
+     * Remove NameIdentifier
+     *
+     * @param NameIdentifier $NameIdentifier
+     * @return void
+     */
+    public function removeNameIdentifier(NameIdentifier $NameIdentifier)
+    {
+        $this->NameIdentifier[] = $NameIdentifier;
     }
 
     /**
@@ -143,9 +155,19 @@ class Contributor
      *
      * @return array
      */
+    public function getNameIdentifier()
+    {
+        return $this->NameIdentifier;
+    }
+
+    /**
+     * Get NameIdentifiers
+     *
+     * @return array
+     */
     public function getNameIdentifiers()
     {
-        return $this->NameIdentifiers;
+        return $this->NameIdentifier;
     }
 
     /**

--- a/src/Product/Contributor.php
+++ b/src/Product/Contributor.php
@@ -53,6 +53,12 @@ class Contributor
     protected $KeyNames;
 
     /**
+     * Website
+     *
+     * @var Website
+     */
+    protected $Website;
+    /**
      * Set SequenceNumber
      *
      * @param int $SequenceNumber
@@ -227,6 +233,27 @@ class Contributor
     public function isAuthor()
     {
         return $this->ContributorRole->getCode() === self::CODE_AUTHOR;
+    }
+
+     /**
+     * Set Website
+     *
+     * @param Website $Website
+     * @return void
+     */
+    public function setWebsite(Website $Website)
+    {
+        $this->Website = $Website;
+    }
+
+    /**
+     * Get Website
+     *
+     * @return Website
+     */
+    public function getWebsite()
+    {
+        return $this->Website;
     }
 
 }

--- a/src/Product/Contributor.php
+++ b/src/Product/Contributor.php
@@ -82,7 +82,6 @@ class Contributor
      */
     public function addNameIdentifier(NameIdentifier $NameIdentifier)
     {
-        echo "Hitting addNameIdentifier\n";
         $this->NameIdentifier[] = $NameIdentifier;
     }
 

--- a/src/Product/DescriptiveDetail.php
+++ b/src/Product/DescriptiveDetail.php
@@ -75,11 +75,11 @@ class DescriptiveDetail
     protected $Contributor = [];
 
     /**
-     * ContributorStatement
+     * Array of ContributorStatements
      *
      * @var string
      */
-    protected $ContributorStatement;
+    protected $ContributorStatement = [];
 
     /**
      * EditionNumber
@@ -272,14 +272,14 @@ class DescriptiveDetail
     }
 
     /**
-     * Set ContributorStatement
+     * Add ContributorStatement
      *
      * @param string $ContributorStatement
      * @return void
      */
-    public function setContributorStatement(string $ContributorStatement)
+    public function addContributorStatement(string $ContributorStatement)
     {
-        $this->ContributorStatement = $ContributorStatement;
+        $this->ContributorStatement[] = $ContributorStatement;
     }
 
     /**

--- a/src/Product/Product.php
+++ b/src/Product/Product.php
@@ -206,17 +206,6 @@ class Product
         $this->RelatedMaterial = $RelatedMaterial;
     }
 
-    // /**
-    //  * Set ProductSupply
-    //  *
-    //  * @param ProductSupply $ProductSupply
-    //  * @return void
-    //  */
-    // public function setProductSupply(ProductSupply $ProductSupply)
-    // {
-    //     $this->ProductSupply = $ProductSupply;
-    // }
-
     /**
      * Add a new Product Supply
      *

--- a/src/Product/Product.php
+++ b/src/Product/Product.php
@@ -81,9 +81,9 @@ class Product
     /**
      * ProductSupply
      *
-     * @var ProductSupply
+     * @var array|ProductSupply
      */
-    protected $ProductSupply;
+    protected $ProductSupply = [];
 
     /**
      * Set the Products record reference
@@ -206,15 +206,37 @@ class Product
         $this->RelatedMaterial = $RelatedMaterial;
     }
 
+    // /**
+    //  * Set ProductSupply
+    //  *
+    //  * @param ProductSupply $ProductSupply
+    //  * @return void
+    //  */
+    // public function setProductSupply(ProductSupply $ProductSupply)
+    // {
+    //     $this->ProductSupply = $ProductSupply;
+    // }
+
     /**
-     * Set ProductSupply
+     * Add a new Product Supply
      *
-     * @param ProductSupply $ProductSupply
+     * @param ProductSupply $productSupply
      * @return void
      */
-    public function setProductSupply(ProductSupply $ProductSupply)
+    public function addProductSupply(ProductSupply $productSupply)
     {
-        $this->ProductSupply = $ProductSupply;
+        $this->ProductSupply[] = $productSupply;
+    }
+
+    /**
+     * Remove Product Supply
+     *
+     * @param ProductSupply $productSupply
+     * @return void
+     */
+    public function removeProductSupply(ProductSupply $productSupply)
+    {
+        $this->ProductSupply[] = $productSupply;
     }
 
     /**

--- a/src/Product/ProductFormFeature.php
+++ b/src/Product/ProductFormFeature.php
@@ -4,6 +4,7 @@ namespace Ribal\Onix\Product;
 
 use Ribal\Onix\CodeList\CodeList79;
 use Ribal\Onix\CodeList\CodeList98;
+use Ribal\Onix\CodeList\CodeList220;
 
 class ProductFormFeature
 {
@@ -43,10 +44,10 @@ class ProductFormFeature
     /**
      * Set ProductFormFeatureValue
      *
-     * @param CodeList98 $ProductFormFeatureValue
+     * @param CodeList220 | CodeList98 $ProductFormFeatureValue
      * @return void
      */
-    public function setProductFormFeatureValue(CodeList98 $ProductFormFeatureValue)
+    public function setProductFormFeatureValue(CodeList220 | CodeList98 $ProductFormFeatureValue)
     {
         $this->ProductFormFeatureValue = $ProductFormFeatureValue;
     }

--- a/src/Product/RelatedWork.php
+++ b/src/Product/RelatedWork.php
@@ -15,11 +15,11 @@ class RelatedWork
     protected $WorkRelationCode;
 
     /**
-     * WorkIdentifier
+     * Array of WorkIdentifiers
      *
-     * @var WorkIdentifier
+     * @var arrayWorkIdentifier
      */
-    protected $WorkIdentifier;
+    protected $WorkIdentifier = [];
 
     /**
      * Set WorkRelationCode
@@ -33,14 +33,14 @@ class RelatedWork
     }
 
     /**
-     * Set WorkIdentifier
+     * Add a new WorkIdentifier
      *
      * @param WorkIdentifier $WorkIdentifier
      * @return void
      */
-    public function setWorkIdentifier(WorkIdentifier $WorkIdentifier)
+    public function addWorkIdentifier(WorkIdentifier $WorkIdentifier)
     {
-        $this->WorkIdentifier = $WorkIdentifier;
+        $this->WorkIdentifier[] = $WorkIdentifier;
     }
 
     /**
@@ -56,11 +56,21 @@ class RelatedWork
     /**
      * WorkIdentifier
      *
-     * @return WorkIdentifier
+     * @return array
      */
     public function getWorkIdentifier()
     {
         return $this->WorkIdentifier;
+    }
+
+     /**
+     * Remove WorkIdentifier
+     *
+     * @param WorkIdentifier $WorkIdentifier
+     * @return void
+     */
+    public function removeWorkIdentifier(WorkIdentifier $WorkIdentifier)
+    {
     }
 
 }

--- a/src/Product/Stock.php
+++ b/src/Product/Stock.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Ribal\Onix\Product;
+
+class Stock
+{
+    /**
+     * LocationName
+     *
+     * @var string
+     */
+    protected $LocationName;
+
+    /**
+     * OnHand
+     *
+     * @var int
+     */
+    protected $OnHand;
+
+    /**
+     * Set LocationName
+     *
+     * @param string $LocationName
+     * @return void
+     */
+    public function setLocationName(string $LocationName)
+    {
+        $this->LocationName = $LocationName;
+    }
+
+    /**
+     * Get PublisherName
+     *
+     * @return string
+     */
+    public function getLocationName()
+    {
+        return $this->LocationName;
+    }
+
+    /**
+     * Set OnHand
+     *
+     * @param string $OnHand
+     * @return void
+     */
+    public function setOnHand(int $OnHand)
+    {
+        $this->OnHand = $OnHand;
+    }
+
+    /**
+     * Get OnHand
+     *
+     * @return string
+     */
+    public function getOnHand()
+    {
+        return $this->OnHand;
+    }
+}

--- a/src/Product/SupplyDetail.php
+++ b/src/Product/SupplyDetail.php
@@ -29,6 +29,13 @@ class SupplyDetail
     protected $ProductAvailability;
 
     /**
+     * Stock
+     *
+     * @var Stock
+     */
+    protected $Stock;
+
+    /**
      * PackQuantity
      *
      * @var int
@@ -142,6 +149,27 @@ class SupplyDetail
     public function getProductAvailability()
     {
         return $this->ProductAvailability;
+    }
+
+    /**
+     * Get Stock
+     *
+     * @return Stock
+     */
+    public function getStock()
+    {
+        return $this->Stock;
+    }
+
+    /**
+     * Set Stock
+     *
+     * @param Stock $Stock
+     * @return void
+     */
+    public function setStock(Stock $Stock)
+    {
+        $this->Stock = $Stock;
     }
 
     /**

--- a/src/Product/TextContent.php
+++ b/src/Product/TextContent.php
@@ -10,7 +10,7 @@ use Ribal\Onix\TextNode;
 class TextContent
 {
 
-	private const CODE_MAINDESCRIPTION = '03';
+    private const CODE_MAINDESCRIPTION = '03';
 
     /**
      * Type of the Text
@@ -32,6 +32,13 @@ class TextContent
      * @var string
      */
     protected $SourceTitle;
+
+    /**
+     * TextAuthor
+     *
+     * @var string
+     */
+    protected $TextAuthor;
 
     /**
      * Text
@@ -71,6 +78,27 @@ class TextContent
     public function setSourceTitle(string $SourceTitle)
     {
         $this->SourceTitle = $SourceTitle;
+    }
+
+    /**
+     * Set TextAuthor
+     *
+     * @param string $TextAuthor
+     * @return void
+     */
+    public function setTextAuthor(string $TextAuthor)
+    {
+        $this->TextAuthor = $TextAuthor;
+    }
+
+    /**
+     * Get TextAuthor
+     *
+     * @return string $TextAuthor
+     */
+    public function getTextAuthor()
+    {
+        return $this->TextAuthor;
     }
 
     /**


### PR DESCRIPTION
Thanks so much for creating this library.

When parsing an Onix feed, we have multiple `<productsupply>` tags. We can also have multiple contributor statements. Also code 79, routes to code list 220 as well as 98. As per the routings here - https://onix-codelists.io/codelist/79 - not exhaustive!

This is valid Onix XML. We have fixed this in our fork.